### PR TITLE
Refactor parser(Fixed double free & Memleaks), Fixed build with 5.2-5.4

### DIFF
--- a/jsond.c
+++ b/jsond.c
@@ -73,7 +73,7 @@ static const zend_function_entry jsond_functions[] = {
 	PHP_JSOND_FE(decode, arginfo_jsond_decode)
 	PHP_JSOND_FE(last_error, arginfo_jsond_last_error)
 	PHP_JSOND_FE(last_error_msg, arginfo_jsond_last_error_msg)
-	PHP_FE_END
+	{NULL, NULL, NULL, NULL}
 };
 /* }}} */
 
@@ -84,7 +84,7 @@ ZEND_END_ARG_INFO();
 
 static const zend_function_entry jsond_serializable_interface[] = {
 	PHP_ABSTRACT_ME(PHP_JSOND_SERIALIZABLE_INTERFACE, PHP_JSOND_SERIALIZABLE_METHOD, jsond_serialize_arginfo)
-	PHP_FE_END
+	{NULL, NULL, NULL, NULL}
 };
 /* }}} */
 
@@ -121,7 +121,7 @@ static PHP_MINIT_FUNCTION(jsond)
 	PHP_JSOND_REGISTER_LONG_CONSTANT("OBJECT_AS_ARRAY",		PHP_JSON_OBJECT_AS_ARRAY,		CONST_CS | CONST_PERSISTENT);
 	PHP_JSOND_REGISTER_LONG_CONSTANT("BIGINT_AS_STRING",		PHP_JSON_BIGINT_AS_STRING,		CONST_CS | CONST_PERSISTENT);
 
-	return SUCCESS;
+
 }
 /* }}} */
 

--- a/jsond_parser.tab.c
+++ b/jsond_parser.tab.c
@@ -1624,7 +1624,7 @@ yyreduce:
         case 2:
 /* Line 1807 of yacc.c  */
 #line 76 "jsond_parser.y"
-    { (yyval) = (yyvsp[(1) - (2)]); ZVAL_ZVAL(parser->return_value, &(yyvsp[(1) - (2)]), 0, 0); ZVAL_NULL(&(yyval)); PHP_JSON_USE((yyvsp[(2) - (2)])); YYACCEPT; }
+    { (yyval) = (yyvsp[(1) - (2)]); INIT_PZVAL_COPY(parser->return_value, &(yyvsp[(1) - (2)])); ZVAL_NULL(&(yyval)); PHP_JSON_USE((yyvsp[(2) - (2)])); YYACCEPT; }
     break;
 
   case 3:

--- a/jsond_parser.y
+++ b/jsond_parser.y
@@ -73,7 +73,7 @@ void php_json_parser_ht_append(zval *ht, zval *zvalue);
 %% /* Rules */
 
 start:
-		value PHP_JSON_T_EOI    { $$ = $1; ZVAL_ZVAL(parser->return_value, &$1, 0, 0); ZVAL_NULL(&$$); PHP_JSON_USE($2); YYACCEPT; }
+		value PHP_JSON_T_EOI    { $$ = $1; INIT_PZVAL_COPY(parser->return_value, &$1); ZVAL_NULL(&$$); PHP_JSON_USE($2); YYACCEPT; }
 	|	value errlex            { PHP_JSON_USE_2($$, $1, $2); }
 ;
 

--- a/php_jsond.h
+++ b/php_jsond.h
@@ -58,6 +58,10 @@ extern zend_module_entry jsond_module_entry;
 #define PHP_JSOND_IDENT(jname) jsond_ ## jname
 #endif
 
+#ifndef HASH_KEY_NON_EXISTENT
+#define HASH_KEY_NON_EXISTENT HASH_KEY_NON_EXISTANT
+#endif
+
 #define PHP_JSOND_FUNCTION(jname) PHP_FUNCTION(PHP_JSOND_IDENT(jname))
 #define PHP_JSOND_FE(jname, arginfo) PHP_FE(PHP_JSOND_IDENT(jname), arginfo)
 #define PHP_JSOND_REGISTER_LONG_CONSTANT(name, lval, flags) REGISTER_LONG_CONSTANT(PHP_JSOND_CONSTANT name, lval, flags)


### PR DESCRIPTION
1. it can be compiled with PHP-5.2 ~ PHP-5.4
2. previously, you copy zval without deep copy, it will cause double free when %destruct is called.
3. fixed some macro defined

now, mosts tests of ext/json are passed (failed tests are most due to warning message)
