### PR TITLE
Correct flags in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ JsondSerializable {
 
 ### Drop-in alternative for the standard JSON extension
 
-If jsond is compiled with `--enable-jsond-with-json-prefix`, than the json functions are replaced
+If jsond is compiled with `--enable-jsond-prefixing`, than the json functions are replaced
 with jsond variants and the API is exactly the same as the API documented in [JSON documentation](http://php.net/json).
 
 ### JSOND IDE Auto Complete


### PR DESCRIPTION
The flag to act as a drop-in alternative is incorrect.

# Check whether --enable-jsond-prefixing was given.
if test "${enable_jsond_prefixing+set}" = set; then :
  enableval=$enable_jsond_prefixing;
$as_echo "#define PHP_JSOND_WITH_JSON_PREFIX 1" >>confdefs.h

fi